### PR TITLE
feat: add tsm_system_row sampling

### DIFF
--- a/canary/__init__.py
+++ b/canary/__init__.py
@@ -227,7 +227,7 @@ class Canary:
                     timestamp=timestamp,
                 )
             except Exception as e:
-                # self.send_slack_notification(f"Error in get_roots: {e}")
+                self.send_slack_notification(f"Error in get_roots: {e}")
                 logging.error(e)
                 continue
 

--- a/canary/__init__.py
+++ b/canary/__init__.py
@@ -275,10 +275,9 @@ class Canary:
             message (str): The message to send.
         """
         try:
-            # self.slack_client.chat_postMessage(
-            #     channel=self.slack_channel, text=message, blocks=blocks
-            # )
-            print(f"Slack Message: {message}")
+            self.slack_client.chat_postMessage(
+                channel=self.slack_channel, text=message, blocks=blocks
+            )
         except SlackApiError as e:
             logging.error(f"Error sending Slack message: {e}")
 

--- a/canary/__init__.py
+++ b/canary/__init__.py
@@ -160,7 +160,6 @@ class Canary:
         async_engine,
         table_name: str,
         sample_percent: int = 10,
-        use_tsm_system_rows_extension: bool = False,
     ):
         """
         Queries the specified data and checks the roots.
@@ -176,7 +175,7 @@ class Canary:
         async with async_engine.begin() as conn:
             sample_query = (
                 f"SELECT * FROM {table_name} TABLESAMPLE SYSTEM_ROWS({self.num_test_annotations})"
-                if use_tsm_system_rows_extension
+                if self.use_tsm_system_rows_extension
                 else f"SELECT * FROM {table_name} TABLESAMPLE system ({sample_percent}) WHERE random()<0.01 LIMIT {self.num_test_annotations}"
             )
             try:
@@ -189,7 +188,7 @@ class Canary:
             if not df.empty:
                 has_error = self.check_root_ids(df, table_name)
                 logging.debug(f"TABLE NAME: {table_name}")
-                logging.debug(f"USING SYSTEM_ROWS:{use_tsm_system_rows_extension}")
+                logging.debug(f"USING SYSTEM_ROWS:{self.use_tsm_system_rows_extension}")
                 logging.debug(df.id.describe())
                 logging.debug(f"ERROR FOUND? {has_error}")
             else:

--- a/canary/__init__.py
+++ b/canary/__init__.py
@@ -114,7 +114,7 @@ class Canary:
         except RuntimeError:
             loop = None
 
-        if use_tsm_system_rows_extension:
+        if self.use_tsm_system_rows_extension:
             # check if postgresql extension is installed on database
             await self.check_if_extension_is_installed(extension_name="tsm_system_rows")
 
@@ -189,7 +189,7 @@ class Canary:
             if not df.empty:
                 has_error = self.check_root_ids(df, table_name)
                 logging.debug(f"TABLE NAME: {table_name}")
-                logging.debug("USING SYSTEM_ROWS:{use_tsm_system_rows_extension}")
+                logging.debug(f"USING SYSTEM_ROWS:{use_tsm_system_rows_extension}")
                 logging.debug(df.id.describe())
                 logging.debug(f"ERROR FOUND? {has_error}")
             else:

--- a/config.example
+++ b/config.example
@@ -6,3 +6,4 @@ SLACK_CHANNEL = dummy_slack_channel
 NUM_TEST_ANNOTATIONS = 100
 CHECK_INTERVAL = 60
 DATABASE_URI = "postgresql+asyncpg://postgres:password@localhost:5432/database"
+USE_TSM_SYSTEM_ROWS=False

--- a/tests/test_canary.py
+++ b/tests/test_canary.py
@@ -117,7 +117,7 @@ async def test_check_random_annotations(
         mock_create_async_engine.return_value = mock_async_engine
 
         # Run the method and capture the result
-        result = await canary_instance.check_random_annotations()
+        result = await canary_instance.check_random_annotations(table_name="example_table", version_info={"is_merged": False})
 
     # Check if the method returned the expected result
     assert result is False


### PR DESCRIPTION
In an attempt to have better coverage of our rows in each table for random sampling we can now optionally use this extension that comes with PostgreSQL: [tsm_system_rows]( https://www.postgresql.org/docs/current/tsm-system-rows.html)

An additional optional config boolean can be set to use the extension. If it is not found on the database we first will try to create it.

Finally, the tasks for checking for root ids are now sent to the server more efficiently 